### PR TITLE
feat(fxsql): Added RunFxSQLSeedsAndShutdown

### DIFF
--- a/fxsql/module.go
+++ b/fxsql/module.go
@@ -171,3 +171,15 @@ func RunFxSQLSeeds(names ...string) fx.Option {
 		},
 	)
 }
+
+// RunFxSQLSeedsAndShutdown runs database seeds with a context and shutodwn.
+func RunFxSQLSeedsAndShutdown(names ...string) fx.Option {
+	return fx.Invoke(
+		func(ctx context.Context, seeder *Seeder, shutdown fx.Shutdowner) error {
+			//nolint:errcheck
+			defer shutdown.Shutdown()
+
+			return seeder.Run(ctx, names...)
+		},
+	)
+}


### PR DESCRIPTION
This is useful for e.g. providing a CLI that seeds a "real" DB for
development

Signed-off-by: Matthias Riegler <matthias.riegler@ankorstore.com>
