### PR TITLE
fix(fxhttpserver): Fix HTTP handlers/middlewares dependency injection signature 

### DIFF
--- a/fxhttpserver/reflect.go
+++ b/fxhttpserver/reflect.go
@@ -6,14 +6,41 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// GetType returns the type of a target.
-func GetType(target any) string {
-	return reflect.TypeOf(target).String()
+// fullTypeID builds a stable identifier for a type in the form "<pkgpath>.<TypeName>".
+func fullTypeID(t reflect.Type) string {
+	if t == nil {
+		return ""
+	}
+
+	// Unwrap pointers to get the underlying named type (if any).
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	// For named types, PkgPath() + Name() gives a unique and stable identity.
+	if t.Name() != "" && t.PkgPath() != "" {
+		return t.PkgPath() + "." + t.Name()
+	}
+
+	// Fallback for non-named kinds (slices, maps, func, etc.).
+	return t.String()
 }
 
-// GetReturnType returns the return type of a target.
+// GetType returns a stable identifier for the given target’s type.
+func GetType(target any) string {
+	return fullTypeID(reflect.TypeOf(target))
+}
+
+// GetReturnType returns a stable identifier for the return type of constructor-like target.
+// If a target is a function, we examine its first return value (index 0), unwrap pointers, and
+// build an identifier for that named type. For non-function or empty-return cases, we return "".
 func GetReturnType(target any) string {
-	return reflect.TypeOf(target).Out(0).String()
+	t := reflect.TypeOf(target)
+	if t == nil || t.Kind() != reflect.Func || t.NumOut() == 0 {
+		return ""
+	}
+
+	return fullTypeID(t.Out(0))
 }
 
 // IsConcreteMiddleware returns true if the middleware is a concrete [echo.MiddlewareFunc] implementation.

--- a/fxhttpserver/reflect_test.go
+++ b/fxhttpserver/reflect_test.go
@@ -15,11 +15,12 @@ func TestGetType(t *testing.T) {
 		target   any
 		expected string
 	}{
+		{nil, ""},
 		{123, "int"},
 		{"test", "string"},
 		{echo.MiddlewareFunc(func(next echo.HandlerFunc) echo.HandlerFunc {
 			return next
-		}), "echo.MiddlewareFunc"},
+		}), "github.com/labstack/echo/v4.MiddlewareFunc"},
 	}
 
 	for _, tt := range tests {
@@ -41,8 +42,12 @@ func TestGetReturnType(t *testing.T) {
 		target   any
 		expected string
 	}{
+		{nil, ""},
 		{func() string { return "test" }, "string"},
 		{func() int { return 123 }, "int"},
+		{echo.MiddlewareFunc(func(next echo.HandlerFunc) echo.HandlerFunc {
+			return next
+		}), "github.com/labstack/echo/v4.HandlerFunc"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #361

### What changed:
Replaced reflect.Type.String()-based type identification with a robust builder that uses PkgPath() + Name() for named types, after unwrapping pointers and inspecting constructor return types. Updated GetType and GetReturnType accordingly.

### Why:
To prevent resolution collisions between handlers/middlewares that share the same package and type names under different import paths (e.g., admin vs public), which led to the wrong handler being invoked.

### How to reproduce the bug (before the fix):
  1. Define two handlers with identical package and type names in different modules:
     - internal/ports/http/public/endpoints/web_auth_login_v1.Handler
     - internal/ports/http/admin/endpoints/web_auth_login_v1.Handler
  2. Register them via generated group registrations.
  3. Call POST /admin/web/auth/login/v1 and observe that the public handler implementation can be executed.

### How to verify the fix:
  1. Start the server with debug logging enabled.
  2. Call both:
     - POST /admin/web/auth/login/v1
     - POST /public/web/auth/login/v1
  3. Confirm each endpoint triggers the correct handler from its respective package and that logs enumerate unique identifiers for admin vs public handlers.
