### PR TITLE
feat(fxcore): Make tasks page configurable

### DIFF
--- a/fxcore/module.go
+++ b/fxcore/module.go
@@ -522,6 +522,7 @@ func withHandlers(coreServer *echo.Echo, p FxCoreParam) (*echo.Echo, error) {
 				"tasksExpose":                  tasksExpose,
 				"tasksPath":                    tasksPath,
 				"tasksNames":                   p.TaskRegistry.Names(),
+				"tasksTemplateSettings":        p.TaskRegistry.TemplateSettings(),
 				"metricsExpose":                metricsExpose,
 				"metricsPath":                  metricsPath,
 				"startupExpose":                startupExpose,

--- a/fxcore/task_test.go
+++ b/fxcore/task_test.go
@@ -25,6 +25,7 @@ func TestTaskRegistry(t *testing.T) {
 			Tasks: []fxcore.Task{
 				tasks.NewSuccessTask(cfg),
 				tasks.NewErrorTask(),
+				tasks.NewTemplateSettingsTask(),
 			},
 		})
 	}
@@ -34,7 +35,7 @@ func TestTaskRegistry(t *testing.T) {
 
 		registry := createRegistry(t)
 
-		assert.Equal(t, []string{"error", "success"}, registry.Names())
+		assert.Equal(t, []string{"error", "success", "template-settings"}, registry.Names())
 	})
 
 	t.Run("test run with success task", func(t *testing.T) {
@@ -78,5 +79,32 @@ func TestTaskRegistry(t *testing.T) {
 		assert.False(t, res.Success)
 		assert.Equal(t, "task invalid not found", res.Message)
 		assert.Nil(t, res.Details)
+	})
+
+	t.Run("test template settings", func(t *testing.T) {
+		t.Parallel()
+
+		registry := createRegistry(t)
+		settings := registry.TemplateSettings()
+
+		assert.Len(t, settings, 3)
+
+		successSettings, ok := settings["success"]
+		assert.True(t, ok)
+		assert.Equal(t, "Optional input...", successSettings.Placeholder)
+		assert.Equal(t, "", successSettings.DefaultValue)
+		assert.Equal(t, 1, successSettings.Rows)
+
+		errorSettings, ok := settings["error"]
+		assert.True(t, ok)
+		assert.Equal(t, "Optional input...", errorSettings.Placeholder)
+		assert.Equal(t, "", errorSettings.DefaultValue)
+		assert.Equal(t, 1, errorSettings.Rows)
+
+		templateSettings, ok := settings["template-settings"]
+		assert.True(t, ok)
+		assert.Equal(t, "Custom placeholder", templateSettings.Placeholder)
+		assert.Equal(t, "Default content", templateSettings.DefaultValue)
+		assert.Equal(t, 5, templateSettings.Rows)
 	})
 }

--- a/fxcore/templates/dashboard.html
+++ b/fxcore/templates/dashboard.html
@@ -125,7 +125,8 @@
                         </div>
                         <div class="list-group list-group-flush">
                             {{ range $taskName := .tasksNames }}
-                            <a @click="loadContent" href="#" role="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" title="Task {{ $taskName }}" data-title='<i class="bi bi-clipboard2"></i>&nbsp;&nbsp;Task {{ $taskName }}' data-type="task" data-task="{{ $taskName }}" data-view="task">
+                            {{ $settings := index $.tasksTemplateSettings $taskName }}
+                            <a @click="loadContent" href="#" role="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" title="Task {{ $taskName }}" data-title='<i class="bi bi-clipboard2"></i>&nbsp;&nbsp;Task {{ $taskName }}' data-type="task" data-task="{{ $taskName }}" data-view="task" data-placeholder="{{ $settings.Placeholder }}" data-default-value="{{ $settings.DefaultValue }}" data-rows="{{ $settings.Rows }}">
                                 <span><i class="bi bi-clipboard2"></i>&nbsp;&nbsp;{{ $taskName }}</span>
                             </a>
                             {{ else }}
@@ -281,7 +282,7 @@
                         <div id="task-body" class="card-body bg-{{ .theme }}" v-if="view == 'task'">
                             <form>
                                 <div class="mb-3">
-                                    <textarea class="form-control" id="taskInput" rows="1" v-model="taskInput" placeholder="Optional input..."></textarea>
+                                    <textarea class="form-control" id="taskInput" :rows="taskRows" v-model="taskInput" :placeholder="taskPlaceholder"></textarea>
                                 </div>
                                 <div class="mb-3 btn-toolbar justify-content-between" role="toolbar" aria-label="Task actions">
                                     <button @click="resetTask" type="button" class="btn btn-sm btn-secondary" :disabled="taskRunning">
@@ -338,8 +339,15 @@
                 taskName: {
                     type: String,
                 },
+                taskPlaceholder: {
+                    type: String,
+                },
                 taskInput: {
                     type: String,
+                },
+                taskRows: {
+                    type: Number,
+                    default: 1
                 },
                 taskRunning: {
                     type: Boolean,
@@ -362,13 +370,15 @@
                 const view = ref('overview');
                 const content = ref('');
                 const taskName = ref('');
+                const taskPlaceholder = ref('');
                 const taskInput = ref('');
+                const taskRows = ref(1);
                 const taskRunning = ref(false);
                 const taskResultSuccess = ref(true);
                 const taskResultMessage = ref('');
                 const taskResultDetails = ref(undefined);
 
-                return { error, loading, title, view, content, taskName, taskInput, taskRunning, taskResultSuccess,  taskResultMessage, taskResultDetails}
+                return { error, loading, title, view, content, taskName, taskPlaceholder, taskInput, taskRows, taskRunning, taskResultSuccess,  taskResultMessage, taskResultDetails}
             },
             methods: {
                 loadContent(event) {
@@ -386,6 +396,19 @@
 
                         this.title = dataTitle;
                         this.taskName = event.currentTarget.getAttribute('data-task');
+                        this.taskPlaceholder = event.currentTarget.getAttribute('data-placeholder');
+
+                        const defaultValue = event.currentTarget.getAttribute('data-default-value');
+                        if (defaultValue) {
+                            this.taskInput = defaultValue;
+                        }
+
+                        const rows = event.currentTarget.getAttribute('data-rows');
+                        if (rows && !isNaN(parseInt(rows))) {
+                            this.taskRows = parseInt(rows);
+                        } else {
+                            this.taskRows = 1;
+                        }
                     } else {
                         this.loading = true
 

--- a/fxcore/testdata/tasks/template_settings.go
+++ b/fxcore/testdata/tasks/template_settings.go
@@ -1,0 +1,35 @@
+package tasks
+
+import (
+	"context"
+
+	"github.com/ankorstore/yokai/fxcore"
+)
+
+var _ fxcore.Task = (*TemplateSettingsTask)(nil)
+var _ fxcore.TaskWithTemplateSettings = (*TemplateSettingsTask)(nil)
+
+type TemplateSettingsTask struct{}
+
+func NewTemplateSettingsTask() *TemplateSettingsTask {
+	return &TemplateSettingsTask{}
+}
+
+func (t *TemplateSettingsTask) Name() string {
+	return "template-settings"
+}
+
+func (t *TemplateSettingsTask) Run(context.Context, []byte) fxcore.TaskResult {
+	return fxcore.TaskResult{
+		Success: true,
+		Message: "template settings task",
+	}
+}
+
+func (t *TemplateSettingsTask) TemplateSettings(settings fxcore.TaskTemplateSettings) fxcore.TaskTemplateSettings {
+	settings.Placeholder = "Custom placeholder"
+	settings.DefaultValue = "Default content"
+	settings.Rows = 5
+
+	return settings
+}


### PR DESCRIPTION
This PR introduces a new interface `TaskWithTemplateSettings` that enhances the customization options for task display in the dashboard.

Previously, all tasks shared the same textarea configuration in the dashboard UI. This new interface allows individual tasks to customize their presentation by specifying:

- **Placeholder text**: Custom instructional text shown when the textarea is empty
- **Default value**: Pre-populated content in the textarea when the task is selected
- **Number of rows**: Vertical size of the textarea to accommodate different input requirements

Here's an example of implementation:
```go
package task

import (
	"context"

	"github.com/ankorstore/yokai/fxcore"
)

var _ fxcore.Task = (*DemoTask)(nil)

type DemoTask struct {
}

func NewDemoTask() *DemoTask {
	return &DemoTask{}
}

func (d DemoTask) Name() string {
	return "demo"
}

func (d DemoTask) Run(ctx context.Context, input []byte) fxcore.TaskResult {
	return fxcore.TaskResult{
		Success: true,
		Message: "Hello",
	}
}

func (d DemoTask) TemplateSettings(settings fxcore.TaskTemplateSettings) fxcore.TaskTemplateSettings {
	settings.DefaultValue = "{}"
	settings.Rows = 3

	return settings
}
```

This enhancement improves the user experience by allowing task-specific customization of the input area, making the dashboard more intuitive and user-friendly.