### PR TITLE
feat(fxcore): Add HTML content escaping toggle for task results

### DIFF
--- a/fxcore/task.go
+++ b/fxcore/task.go
@@ -26,15 +26,17 @@ type TaskWithTemplateSettings interface {
 }
 
 type TaskTemplateSettings struct {
-	Placeholder  string
-	DefaultValue string
-	Rows         int
+	Placeholder   string
+	DefaultValue  string
+	Rows          int
+	EscapeContent bool
 }
 
 func DefaultTaskTemplateSettings() TaskTemplateSettings {
 	return TaskTemplateSettings{
-		Placeholder: "Optional input...",
-		Rows:        1,
+		Placeholder:   "Optional input...",
+		Rows:          1,
+		EscapeContent: true,
 	}
 }
 

--- a/fxcore/task_test.go
+++ b/fxcore/task_test.go
@@ -94,17 +94,20 @@ func TestTaskRegistry(t *testing.T) {
 		assert.Equal(t, "Optional input...", successSettings.Placeholder)
 		assert.Equal(t, "", successSettings.DefaultValue)
 		assert.Equal(t, 1, successSettings.Rows)
+		assert.True(t, successSettings.EscapeContent)
 
 		errorSettings, ok := settings["error"]
 		assert.True(t, ok)
 		assert.Equal(t, "Optional input...", errorSettings.Placeholder)
 		assert.Equal(t, "", errorSettings.DefaultValue)
 		assert.Equal(t, 1, errorSettings.Rows)
+		assert.True(t, errorSettings.EscapeContent)
 
 		templateSettings, ok := settings["template-settings"]
 		assert.True(t, ok)
 		assert.Equal(t, "Custom placeholder", templateSettings.Placeholder)
 		assert.Equal(t, "Default content", templateSettings.DefaultValue)
 		assert.Equal(t, 5, templateSettings.Rows)
+		assert.False(t, templateSettings.EscapeContent)
 	})
 }

--- a/fxcore/templates/dashboard.html
+++ b/fxcore/templates/dashboard.html
@@ -126,7 +126,7 @@
                         <div class="list-group list-group-flush">
                             {{ range $taskName := .tasksNames }}
                             {{ $settings := index $.tasksTemplateSettings $taskName }}
-                            <a @click="loadContent" href="#" role="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" title="Task {{ $taskName }}" data-title='<i class="bi bi-clipboard2"></i>&nbsp;&nbsp;Task {{ $taskName }}' data-type="task" data-task="{{ $taskName }}" data-view="task" data-placeholder="{{ $settings.Placeholder }}" data-default-value="{{ $settings.DefaultValue }}" data-rows="{{ $settings.Rows }}">
+                            <a @click="loadContent" href="#" role="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" title="Task {{ $taskName }}" data-title='<i class="bi bi-clipboard2"></i>&nbsp;&nbsp;Task {{ $taskName }}' data-type="task" data-task="{{ $taskName }}" data-view="task" data-placeholder="{{ $settings.Placeholder }}" data-default-value="{{ $settings.DefaultValue }}" data-rows="{{ $settings.Rows }}" data-escape-content="{{ $settings.EscapeContent }}">
                                 <span><i class="bi bi-clipboard2"></i>&nbsp;&nbsp;{{ $taskName }}</span>
                             </a>
                             {{ else }}
@@ -298,7 +298,8 @@
                             <div class="card mb-3 border-success" v-show="taskResultMessage !== '' && taskResultSuccess && !taskRunning">
                                 <div class="card-header"><i class="bi bi-check2-circle"></i>&nbsp;&nbsp;Task {% taskName %} execution success</div>
                                 <div class="card-body bg-{{ .theme }}">
-                                    <p class="card-text">{% taskResultMessage %}</p>
+                                    <p class="card-text" v-if="!taskEscapeContent" v-html="taskResultMessage"></p>
+                                    <p class="card-text" v-if="taskEscapeContent">{% taskResultMessage %}</p>
                                     <p v-html="computedTaskResultDetails"></p>
                                 </div>
                             </div>
@@ -349,6 +350,9 @@
                     type: Number,
                     default: 1
                 },
+                taskEscapeContent: {
+                    type: Boolean,
+                },
                 taskRunning: {
                     type: Boolean,
                 },
@@ -373,12 +377,13 @@
                 const taskPlaceholder = ref('');
                 const taskInput = ref('');
                 const taskRows = ref(1);
+                const taskEscapeContent = ref(true);
                 const taskRunning = ref(false);
                 const taskResultSuccess = ref(true);
                 const taskResultMessage = ref('');
                 const taskResultDetails = ref(undefined);
 
-                return { error, loading, title, view, content, taskName, taskPlaceholder, taskInput, taskRows, taskRunning, taskResultSuccess,  taskResultMessage, taskResultDetails}
+                return { error, loading, title, view, content, taskName, taskPlaceholder, taskInput, taskRows, taskEscapeContent, taskRunning, taskResultSuccess,  taskResultMessage, taskResultDetails}
             },
             methods: {
                 loadContent(event) {
@@ -409,6 +414,8 @@
                         } else {
                             this.taskRows = 1;
                         }
+
+                        this.taskEscapeContent = event.currentTarget.getAttribute('data-escape-content') === 'true';
                     } else {
                         this.loading = true
 

--- a/fxcore/testdata/tasks/template_settings.go
+++ b/fxcore/testdata/tasks/template_settings.go
@@ -30,6 +30,7 @@ func (t *TemplateSettingsTask) TemplateSettings(settings fxcore.TaskTemplateSett
 	settings.Placeholder = "Custom placeholder"
 	settings.DefaultValue = "Default content"
 	settings.Rows = 5
+	settings.EscapeContent = false
 
 	return settings
 }


### PR DESCRIPTION
This PR adds the ability to toggle between escaped and unescaped HTML content in task results.

This feature allows for rich HTML formatting in task results when needed, while maintaining the option to escape HTML for security purposes.