### PR TITLE
feat(fxcore): Add task grouping support to dashboard sidebar

### DIFF
--- a/docs/modules/fxcore.md
+++ b/docs/modules/fxcore.md
@@ -380,6 +380,33 @@ func Register() fx.Option {
 
 Note: you can also use `AsTasks()` to register several tasks at once.
 
+#### Task grouping
+
+If you have many tasks, you can group them in the dashboard sidebar by also implementing the `GroupedTask` interface:
+
+```go title="internal/tasks/example.go"
+func (t *ExampleTask) Group() string {
+	return "my group"
+}
+```
+
+Tasks sharing the same group name will be collapsed under a single expandable entry in the sidebar, sorted alphabetically by group name alongside standalone tasks.
+
+#### Input customisation
+
+By default, each task is rendered in the dashboard with a single-row textarea and a generic placeholder. You can customise this by implementing the `TaskWithTemplateSettings` interface:
+
+```go title="internal/tasks/example.go"
+func (t *ExampleTask) TemplateSettings(settings fxcore.TaskTemplateSettings) fxcore.TaskTemplateSettings {
+	settings.Placeholder   = "Enter a user ID..."  // input placeholder text (default: "Optional input...")
+	settings.DefaultValue  = "42"                  // pre-filled input value (default: "")
+	settings.Rows          = 5                     // number of textarea rows (default: 1)
+	settings.EscapeContent = false                 // set to false to render result message as HTML (default: true)
+
+	return settings
+}
+```
+
 It'll be then available on the core dashboard for execution:
 
 ![](../../assets/images/dash-tasks-light.png#only-light)

--- a/fxcore/module.go
+++ b/fxcore/module.go
@@ -521,7 +521,7 @@ func withHandlers(coreServer *echo.Echo, p FxCoreParam) (*echo.Echo, error) {
 				"overviewTraceProcessorExpose": overviewTraceProcessorExpose,
 				"tasksExpose":                  tasksExpose,
 				"tasksPath":                    tasksPath,
-				"tasksNames":                   p.TaskRegistry.Names(),
+				"tasksItems":                   p.TaskRegistry.ListItems(),
 				"tasksTemplateSettings":        p.TaskRegistry.TemplateSettings(),
 				"metricsExpose":                metricsExpose,
 				"metricsPath":                  metricsPath,

--- a/fxcore/templates/dashboard.html
+++ b/fxcore/templates/dashboard.html
@@ -124,11 +124,26 @@
                             <i class="bi bi-clipboard2-check"></i>&nbsp;&nbsp;Tasks
                         </div>
                         <div class="list-group list-group-flush">
-                            {{ range $taskName := .tasksNames }}
-                            {{ $settings := index $.tasksTemplateSettings $taskName }}
-                            <a @click="loadContent" href="#" role="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" title="Task {{ $taskName }}" data-title='<i class="bi bi-clipboard2"></i>&nbsp;&nbsp;Task {{ $taskName }}' data-type="task" data-task="{{ $taskName }}" data-view="task" data-placeholder="{{ $settings.Placeholder }}" data-default-value="{{ $settings.DefaultValue }}" data-rows="{{ $settings.Rows }}" data-escape-content="{{ $settings.EscapeContent }}">
-                                <span><i class="bi bi-clipboard2"></i>&nbsp;&nbsp;{{ $taskName }}</span>
+                            {{ range $i, $item := .tasksItems }}
+                            {{ if $item.IsGroup }}
+                            <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" data-bs-toggle="collapse" href="#task-group-{{ $i }}" role="button" aria-expanded="false" aria-controls="task-group-{{ $i }}">
+                                <span><i class="bi bi-folder2"></i>&nbsp;&nbsp;{{ $item.Name }}</span>
+                                <i class="bi bi-chevron-down"></i>
                             </a>
+                            <div class="collapse" id="task-group-{{ $i }}">
+                                {{ range $taskName := $item.Tasks }}
+                                {{ $settings := index $.tasksTemplateSettings $taskName }}
+                                <a @click="loadContent" href="#" role="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center ps-4" title="Task {{ $taskName }}" data-title='<i class="bi bi-clipboard2"></i>&nbsp;&nbsp;Task {{ $taskName }}' data-type="task" data-task="{{ $taskName }}" data-view="task" data-placeholder="{{ $settings.Placeholder }}" data-default-value="{{ $settings.DefaultValue }}" data-rows="{{ $settings.Rows }}" data-escape-content="{{ $settings.EscapeContent }}">
+                                    <span><i class="bi bi-clipboard2"></i>&nbsp;&nbsp;{{ $taskName }}</span>
+                                </a>
+                                {{ end }}
+                            </div>
+                            {{ else }}
+                            {{ $settings := index $.tasksTemplateSettings $item.Name }}
+                            <a @click="loadContent" href="#" role="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" title="Task {{ $item.Name }}" data-title='<i class="bi bi-clipboard2"></i>&nbsp;&nbsp;Task {{ $item.Name }}' data-type="task" data-task="{{ $item.Name }}" data-view="task" data-placeholder="{{ $settings.Placeholder }}" data-default-value="{{ $settings.DefaultValue }}" data-rows="{{ $settings.Rows }}" data-escape-content="{{ $settings.EscapeContent }}">
+                                <span><i class="bi bi-clipboard2"></i>&nbsp;&nbsp;{{ $item.Name }}</span>
+                            </a>
+                            {{ end }}
                             {{ else }}
                             <a class="list-group-item list-group-item-action disabled" aria-disabled="true">
                                 <i class="bi bi-slash-circle"></i>&nbsp;&nbsp;n/a

--- a/fxcore/testdata/tasks/grouped_task.go
+++ b/fxcore/testdata/tasks/grouped_task.go
@@ -1,0 +1,34 @@
+package tasks
+
+import (
+	"context"
+
+	"github.com/ankorstore/yokai/fxcore"
+)
+
+var _ fxcore.Task = (*GroupedTask)(nil)
+var _ fxcore.GroupedTask = (*GroupedTask)(nil)
+
+type GroupedTask struct {
+	name  string
+	group string
+}
+
+func NewGroupedTask(name, group string) *GroupedTask {
+	return &GroupedTask{name: name, group: group}
+}
+
+func (t *GroupedTask) Name() string {
+	return t.name
+}
+
+func (t *GroupedTask) Group() string {
+	return t.group
+}
+
+func (t *GroupedTask) Run(context.Context, []byte) fxcore.TaskResult {
+	return fxcore.TaskResult{
+		Success: true,
+		Message: "grouped task " + t.name,
+	}
+}


### PR DESCRIPTION
  - Introduces a `GroupedTask` interface that tasks can implement to declare a group name                                                                                                                    
  - Adds `TaskRegistry.ListItems()` which returns sidebar items as either standalone tasks or expandable group entries, sorted alphabetically
  - Updates the dashboard HTML template to render group entries as collapsible sections (Bootstrap collapse) with a folder icon and chevron, indenting grouped tasks underneath
  - Adds a `GroupedTask` test fixture and expands `TaskRegistry` tests to cover both grouped and ungrouped scenarios
  - Documents the new interface in `docs/modules/fxcore.md`
