### PR TITLE
chore(healthcheck): update module dependencies

### DIFF
--- a/.github/workflows/healthcheck-ci.yml
+++ b/.github/workflows/healthcheck-ci.yml
@@ -29,3 +29,5 @@ jobs:
         secrets: inherit
         with:
             module: "healthcheck"
+            go_version: "1.24"
+            linter_version: "1.64.8"

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -1,8 +1,8 @@
 module github.com/ankorstore/yokai/healthcheck
 
-go 1.20
+go 1.24
 
-require github.com/stretchr/testify v1.9.0
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/healthcheck/go.sum
+++ b/healthcheck/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

Recreates #376 on top of current `main` (stale since 2025-09-17). Original commit by @adaosantos preserved via cherry-pick. Adds a CI override matching the `fxmcpserver-ci.yml` pattern so Go 1.24 modules can be linted and tested.

Updates `healthcheck/` module dependencies:

- **Go:** `1.20` → `1.24`
- **Testify:** `v1.9.0` → `v1.11.1`

## Verification

- `go mod tidy` no-op against the committed `go.sum`
- `go test ./...` passes (Go 1.24.13)
- `healthcheck-ci.yml` bumped to `go_version: "1.24"` + `linter_version: "1.64.8"`

## Downstream impact

- Consumers must use Go ≥ 1.21.
- No source code changes; only `healthcheck/go.mod`, `healthcheck/go.sum`, and CI.

## Test plan

- [x] CI passes on this branch