### PR TITLE
chore: bump Layer-1 modules to Go 1.26

### DIFF
--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -29,5 +29,5 @@ jobs:
         secrets: inherit
         with:
             module: "config"
-            go_version: "1.24"
+            go_version: "1.26"
             linter_version: "1.64.8"

--- a/.github/workflows/generate-ci.yml
+++ b/.github/workflows/generate-ci.yml
@@ -29,5 +29,5 @@ jobs:
         secrets: inherit
         with:
             module: "generate"
-            go_version: "1.24"
+            go_version: "1.26"
             linter_version: "1.64.8"

--- a/.github/workflows/healthcheck-ci.yml
+++ b/.github/workflows/healthcheck-ci.yml
@@ -29,5 +29,5 @@ jobs:
         secrets: inherit
         with:
             module: "healthcheck"
-            go_version: "1.24"
+            go_version: "1.26"
             linter_version: "1.64.8"

--- a/.github/workflows/log-ci.yml
+++ b/.github/workflows/log-ci.yml
@@ -29,5 +29,5 @@ jobs:
         secrets: inherit
         with:
             module: "log"
-            go_version: "1.24"
+            go_version: "1.26"
             linter_version: "1.64.8"

--- a/.github/workflows/trace-ci.yml
+++ b/.github/workflows/trace-ci.yml
@@ -29,3 +29,5 @@ jobs:
         secrets: inherit
         with:
             module: "trace"
+            go_version: "1.26"
+            linter_version: "1.64.8"

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,8 +1,8 @@
 module github.com/ankorstore/yokai/config
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.6
+toolchain go1.26.4
 
 require (
 	github.com/spf13/viper v1.21.0

--- a/generate/go.mod
+++ b/generate/go.mod
@@ -1,6 +1,8 @@
 module github.com/ankorstore/yokai/generate
 
-go 1.24
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -1,6 +1,8 @@
 module github.com/ankorstore/yokai/healthcheck
 
-go 1.24
+go 1.26.0
+
+toolchain go1.26.4
 
 require github.com/stretchr/testify v1.11.1
 

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,6 +1,8 @@
 module github.com/ankorstore/yokai/log
 
-go 1.24
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/rs/zerolog v1.34.0

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -1,6 +1,8 @@
 module github.com/ankorstore/yokai/trace
 
-go 1.20
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/trace/go.sum
+++ b/trace/go.sum
@@ -10,13 +10,17 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/otel v1.24.0 h1:0LAOdjNmQeSTzGBzduGe/rU4tZhMwL5rWgtp9Ku5Jfo=
@@ -36,6 +40,7 @@ go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw
 go.opentelemetry.io/proto/otlp v1.1.0 h1:2Di21piLrCqJ3U3eXGCTPHE9R8Nh+0uglSnOyxikMeI=
 go.opentelemetry.io/proto/otlp v1.1.0/go.mod h1:GpBHCBWiqvVLDqmHZsoMM3C5ySeKTC7ej/RNTae6MdY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
 golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
@@ -52,5 +57,6 @@ google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGm
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

Scaffold for upgrading the Yokai monorepo to Go 1.26. This PR covers **Layer 1** — modules with zero internal `yokai/*` dependencies — so it can land independently before any `fx*` module is touched.

Modules included (1 commit each):
- `config`
- `generate`
- `healthcheck`
- `log`
- `trace`

For each module:
- `go.mod`: `go 1.20` → `go 1.26.0` + `toolchain go1.26.4`
- `go.sum`: refreshed via `go mod tidy` (no version bumps to direct deps)
- `.github/workflows/<module>-ci.yml`: `go_version: "1.26"` + `linter_version: "1.64.8"`

## Verification

- `go mod tidy` produces only the new toolchain-related entries
- `go test ./...` passes in every module (toolchain go1.26.4 auto-fetched)
- No direct dependency version changes — leaves room for a separate "refresh deps" PR

## Downstream impact

- Consumers of any of these five modules must use **Go ≥ 1.21** (older toolchains can't parse the `toolchain` directive).
- Go 1.21+ will auto-fetch Go 1.26.4 via the toolchain directive.
- No source-code changes — strict drop-in.

## Next steps after this lands

1. Cut releases for the five Layer-1 modules (release-please).
2. Open the **Layer 2 PR** bumping `fxconfig`, `fxgenerate`, `fxhealthcheck`, `fxclock`, `fxlog`, `fxtrace`, `fxvalidator`, `httpclient`, `sql`, `worker`, `orm` to Go 1.26 and pin the new Layer-1 versions.
3. Then **Layer 3** (`fxcore` and the heavy `fx*server` modules).
4. Separately: golangci-lint v1→v2 migration across all 28 `.golangci.yml` files.
5. Once everything lands: bump `common-ci.yml` defaults so future modules don't need per-file overrides.
