### PR TITLE
chore(ci): bump deprecated Node 16/20 actions to Node 24 (PLA-20 follow-up)

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
       - name: Clean cache
@@ -47,7 +47,7 @@ jobs:
         working-directory: ${{ inputs.module }}
         run: rm coverage.tmp.out
       - name: Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false
           flags: ${{ inputs.module }}
@@ -58,11 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
       - name: Install lint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,11 +51,11 @@ jobs:
         - "fxworker"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
       - name: Install dependencies for module ${{ matrix.module }}
@@ -71,7 +71,7 @@ jobs:
         working-directory: ${{ matrix.module }}
         run: rm coverage.tmp.out
       - name: Codecov for module ${{ matrix.module }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false
           flags: ${{ matrix.module }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocs-glightbox


### PR DESCRIPTION
## Context
Follow-up to **PLA-20** (Node 20 -> 24 GitHub Actions). A full org `origin/HEAD` scan found this repo’s **workflow files** still referenced Node 16/20 actions. This PR bumps them to their latest Node 24-compatible major.
## Bumps
- `actions/checkout@v3` -> `actions/checkout@v6`
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-go@v4` -> `actions/setup-go@v6`
- `actions/setup-python@v4` -> `actions/setup-python@v6`
- `codecov/codecov-action@v3` -> `codecov/codecov-action@v7`
## Not included
Actions with no clean Node 24 path (archived, still-node20, or breaking majors like `golangci-lint-action`, `release-please-action`, `slack-github-action`) were intentionally left out and are tracked in **PLA-133**.
