### PR TITLE
feat: trigger Layer-1 and Layer-3 module releases

### DIFF
--- a/config/.golangci.yml
+++ b/config/.golangci.yml
@@ -55,7 +55,6 @@ linters:
     - promlinter
     - reassign
     - staticcheck
-    - tenv
     - thelper
     - tparallel
     - typecheck

--- a/fxclock/README.md
+++ b/fxclock/README.md
@@ -1,5 +1,7 @@
 # Fx Clock Module
 
+Requires Go 1.26+.
+
 [![ci](https://github.com/ankorstore/yokai/actions/workflows/fxclock-ci.yml/badge.svg)](https://github.com/ankorstore/yokai/actions/workflows/fxclock-ci.yml)
 [![go report](https://goreportcard.com/badge/github.com/ankorstore/yokai/fxclock)](https://goreportcard.com/report/github.com/ankorstore/yokai/fxclock)
 [![codecov](https://codecov.io/gh/ankorstore/yokai/graph/badge.svg?token=ghUBlFsjhR&flag=fxclock)](https://app.codecov.io/gh/ankorstore/yokai/tree/main/fxclock)

--- a/fxlog/README.md
+++ b/fxlog/README.md
@@ -1,5 +1,7 @@
 # Fx Log Module
 
+Requires Go 1.26+.
+
 [![ci](https://github.com/ankorstore/yokai/actions/workflows/fxlog-ci.yml/badge.svg)](https://github.com/ankorstore/yokai/actions/workflows/fxlog-ci.yml)
 [![go report](https://goreportcard.com/badge/github.com/ankorstore/yokai/fxlog)](https://goreportcard.com/report/github.com/ankorstore/yokai/fxlog)
 [![codecov](https://codecov.io/gh/ankorstore/yokai/graph/badge.svg?token=ghUBlFsjhR&flag=fxlog)](https://app.codecov.io/gh/ankorstore/yokai/tree/main/fxlog)

--- a/fxtrace/README.md
+++ b/fxtrace/README.md
@@ -1,5 +1,7 @@
 # Fx Trace Module
 
+Requires Go 1.26+.
+
 [![ci](https://github.com/ankorstore/yokai/actions/workflows/fxtrace-ci.yml/badge.svg)](https://github.com/ankorstore/yokai/actions/workflows/fxtrace-ci.yml)
 [![go report](https://goreportcard.com/badge/github.com/ankorstore/yokai/fxtrace)](https://goreportcard.com/report/github.com/ankorstore/yokai/fxtrace)
 [![codecov](https://codecov.io/gh/ankorstore/yokai/graph/badge.svg?token=ghUBlFsjhR&flag=fxtrace)](https://app.codecov.io/gh/ankorstore/yokai/tree/main/fxtrace)

--- a/fxvalidator/README.md
+++ b/fxvalidator/README.md
@@ -1,5 +1,7 @@
 # Fx Validator Module
 
+Requires Go 1.26+.
+
 [![ci](https://github.com/ankorstore/yokai/actions/workflows/fxvalidator-ci.yml/badge.svg)](https://github.com/ankorstore/yokai/actions/workflows/fxvalidator-ci.yml)
 [![go report](https://goreportcard.com/badge/github.com/ankorstore/yokai/fxvalidator)](https://goreportcard.com/report/github.com/ankorstore/yokai/fxvalidator)
 [![codecov](https://codecov.io/gh/ankorstore/yokai/graph/badge.svg?token=ghUBlFsjhR&flag=fxvalidator)](https://app.codecov.io/gh/ankorstore/yokai/tree/main/fxvalidator)

--- a/generate/.golangci.yml
+++ b/generate/.golangci.yml
@@ -55,7 +55,6 @@ linters:
     - promlinter
     - reassign
     - staticcheck
-    - tenv
     - thelper
     - tparallel
     - typecheck

--- a/healthcheck/.golangci.yml
+++ b/healthcheck/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - importas
     - ineffassign
     - interfacebloat
-    - logrlint
+    - loggercheck
     - maintidx
     - makezero
     - misspell
@@ -55,7 +55,6 @@ linters:
     - promlinter
     - reassign
     - staticcheck
-    - tenv
     - thelper
     - tparallel
     - typecheck

--- a/log/.golangci.yml
+++ b/log/.golangci.yml
@@ -39,7 +39,7 @@ linters:
     - importas
     - ineffassign
     - interfacebloat
-    - logrlint
+    - loggercheck
     - maintidx
     - makezero
     - misspell
@@ -54,7 +54,6 @@ linters:
     - promlinter
     - reassign
     - staticcheck
-    - tenv
     - thelper
     - tparallel
     - typecheck

--- a/trace/.golangci.yml
+++ b/trace/.golangci.yml
@@ -39,7 +39,7 @@ linters:
     - importas
     - ineffassign
     - interfacebloat
-    - logrlint
+    - loggercheck
     - maintidx
     - makezero
     - misspell
@@ -54,7 +54,6 @@ linters:
     - promlinter
     - reassign
     - staticcheck
-    - tenv
     - thelper
     - tparallel
     - typecheck


### PR DESCRIPTION
## Summary

The Layer-1 (#407) and Layer-3 (#419) PRs were squash-merged with non-scoped `chore:` titles, so release-please did not generate release PRs for those nine modules. Their Go 1.26 code is on `main` but the module proxy still serves the pre-upgrade versions.

This PR adds nine small, scoped commits — each with a `Release-As:` footer — so release-please will cut release PRs for every missing module.

## Changes

Each commit is a real, useful change (not a no-op):

**Layer 1** — finish the `.golangci.yml` cleanup that L2/L3/L4/L5 already received: drop deprecated `tenv`, rename `logrlint` → `loggercheck` where present:

| Commit | Module | Target version |
|---|---|---|
| `chore(config):` | `config` v1.5.0 → v1.6.0 |
| `chore(generate):` | `generate` v1.3.0 → v1.4.0 |
| `chore(healthcheck):` | `healthcheck` v1.1.0 → v1.2.0 |
| `chore(log):` | `log` v1.2.0 → v1.3.0 |
| `chore(trace):` | `trace` v1.4.0 → v1.5.0 |

**Layer 3** — document the Go 1.26 minimum requirement under each module's title:

| Commit | Module | Target version |
|---|---|---|
| `docs(fxclock):` | `fxclock` v1.0.0 → v1.1.0 |
| `docs(fxvalidator):` | `fxvalidator` v1.0.0 → v1.1.0 |
| `docs(fxlog):` | `fxlog` v1.1.0 → v1.2.0 |
| `docs(fxtrace):` | `fxtrace` v1.2.1 → v1.3.0 |

All target versions match the minor-bump convention that release-please already used for L2 and L4.

## After this lands

Release-please will open nine new release PRs for the L1 and L3 modules. Merge those alongside the L2/L4 release PRs already open (#410–#418, #421–#423). Then L5 (#424) → its release PRs → done. No pin-refresh pass needed.