### PR TITLE
ci: bump common-ci defaults to Go 1.26 / golangci-lint 1.64.8

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -10,11 +10,11 @@ on:
       go_version:
         required: false
         type: string
-        default: "1.20.0"
+        default: "1.26"
       linter_version:
         required: false
         type: string
-        default: "1.55.2"
+        default: "1.64.8"
 
 permissions:
   contents: read

--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "config"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxclock-ci.yml
+++ b/.github/workflows/fxclock-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxclock"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxconfig-ci.yml
+++ b/.github/workflows/fxconfig-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxconfig"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxcore-ci.yml
+++ b/.github/workflows/fxcore-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxcore"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxcron-ci.yml
+++ b/.github/workflows/fxcron-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxcron"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxgenerate-ci.yml
+++ b/.github/workflows/fxgenerate-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxgenerate"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxgrpcserver-ci.yml
+++ b/.github/workflows/fxgrpcserver-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxgrpcserver"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxhealthcheck-ci.yml
+++ b/.github/workflows/fxhealthcheck-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxhealthcheck"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxhttpclient-ci.yml
+++ b/.github/workflows/fxhttpclient-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxhttpclient"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxhttpserver-ci.yml
+++ b/.github/workflows/fxhttpserver-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxhttpserver"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxlog-ci.yml
+++ b/.github/workflows/fxlog-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxlog"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxmcpserver-ci.yml
+++ b/.github/workflows/fxmcpserver-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxmcpserver"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxmetrics-ci.yml
+++ b/.github/workflows/fxmetrics-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxmetrics"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxorm-ci.yml
+++ b/.github/workflows/fxorm-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxorm"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxsql-ci.yml
+++ b/.github/workflows/fxsql-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxsql"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxtrace-ci.yml
+++ b/.github/workflows/fxtrace-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxtrace"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxvalidator-ci.yml
+++ b/.github/workflows/fxvalidator-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxvalidator"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/fxworker-ci.yml
+++ b/.github/workflows/fxworker-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "fxworker"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/generate-ci.yml
+++ b/.github/workflows/generate-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "generate"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/grpcserver-ci.yml
+++ b/.github/workflows/grpcserver-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "grpcserver"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/healthcheck-ci.yml
+++ b/.github/workflows/healthcheck-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "healthcheck"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/httpclient-ci.yml
+++ b/.github/workflows/httpclient-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "httpclient"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/httpserver-ci.yml
+++ b/.github/workflows/httpserver-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "httpserver"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/log-ci.yml
+++ b/.github/workflows/log-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "log"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/orm-ci.yml
+++ b/.github/workflows/orm-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "orm"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/sql-ci.yml
+++ b/.github/workflows/sql-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "sql"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/trace-ci.yml
+++ b/.github/workflows/trace-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "trace"
-            go_version: "1.26"
-            linter_version: "1.64.8"

--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -29,5 +29,3 @@ jobs:
         secrets: inherit
         with:
             module: "worker"
-            go_version: "1.26"
-            linter_version: "1.64.8"


### PR DESCRIPTION
## Summary

Bump `common-ci.yml`'s defaults from `go_version: "1.20.0"` / `linter_version: "1.55.2"` to `go_version: "1.26"` / `linter_version: "1.64.8"`, and drop the now-redundant per-module overrides from all 28 module workflows.

Every module currently sets these inputs explicitly to the new values (they were added as overrides while the bumps rolled out layer by layer). With the upgrade complete, the overrides are noise.

## Behavioural change

**Zero.** Each module previously passed the override explicitly; now they inherit the same value from the default. Net result is identical CI behaviour.
