### PR TITLE
ci: migrate golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -14,7 +14,7 @@ on:
       linter_version:
         required: false
         type: string
-        default: "1.64.8"
+        default: "2.12.2"
 
 permissions:
   contents: read
@@ -67,7 +67,7 @@ jobs:
           go-version: ${{ inputs.go_version }}
       - name: Install lint
         working-directory: ${{ inputs.module }}
-        run:  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v${{ inputs.linter_version }}
+        run:  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${{ inputs.linter_version }}
       - name: Run lint
         working-directory: ${{ inputs.module }}
         run: golangci-lint run

--- a/config/.golangci.yml
+++ b/config/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/config/.golangci.yml
+++ b/config/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxclock/.golangci.yml
+++ b/fxclock/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxclock/.golangci.yml
+++ b/fxclock/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -53,12 +47,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxconfig/.golangci.yml
+++ b/fxconfig/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxconfig/.golangci.yml
+++ b/fxconfig/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxcore/.golangci.yml
+++ b/fxcore/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxcore/.golangci.yml
+++ b/fxcore/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -26,17 +24,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -50,12 +44,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxcore/module.go
+++ b/fxcore/module.go
@@ -468,24 +468,27 @@ func withHandlers(coreServer *echo.Echo, p FxCoreParam) (*echo.Echo, error) {
 	if dashboardEnabled || appDebug {
 		// theme
 		coreServer.POST("/theme", func(c echo.Context) error {
-			themeCookie := new(http.Cookie)
-			themeCookie.Name = "theme"
+			value := ThemeLight
 
 			var theme FxCoreDashboardTheme
-			if err = c.Bind(&theme); err != nil {
-				themeCookie.Value = ThemeLight
-			} else {
+			if err = c.Bind(&theme); err == nil {
 				switch theme.Theme {
 				case ThemeDark:
-					themeCookie.Value = ThemeDark
+					value = ThemeDark
 				case ThemeLight:
-					themeCookie.Value = ThemeLight
-				default:
-					themeCookie.Value = ThemeLight
+					value = ThemeLight
 				}
 			}
 
-			c.SetCookie(themeCookie)
+			// theme is a non-sensitive UI preference; Secure intentionally false so the
+			// dashboard works on http://localhost in dev mode.
+			c.SetCookie(&http.Cookie{ //nolint:gosec
+				Name:     "theme",
+				Value:    value,
+				Path:     "/",
+				HttpOnly: true,
+				SameSite: http.SameSiteLaxMode,
+			})
 
 			return c.Redirect(http.StatusMovedPermanently, "/")
 		})

--- a/fxcron/.golangci.yml
+++ b/fxcron/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxcron/.golangci.yml
+++ b/fxcron/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -51,12 +45,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxcron/module_test.go
+++ b/fxcron/module_test.go
@@ -70,9 +70,9 @@ func TestModule(t *testing.T) {
 			// cron jobs execution tracker
 			fx.Provide(tracker.NewCronExecutionTracker),
 			// cron jobs registration
-			fxcron.AsCronJob(job.NewSuccessCron, `*/1 * * * * *`, gocron.WithLimitedRuns(uint(expectedSuccessRuns))), //nolint:gosec
-			fxcron.AsCronJob(job.NewErrorCron, `*/1 * * * * *`, gocron.WithLimitedRuns(uint(expectedErrorRuns))),     //nolint:gosec
-			fxcron.AsCronJob(job.NewPanicCron, `*/1 * * * * *`, gocron.WithLimitedRuns(uint(expectedPanicRuns))),     //nolint:gosec
+			fxcron.AsCronJob(job.NewSuccessCron, `*/1 * * * * *`, gocron.WithLimitedRuns(uint(expectedSuccessRuns))),
+			fxcron.AsCronJob(job.NewErrorCron, `*/1 * * * * *`, gocron.WithLimitedRuns(uint(expectedErrorRuns))),
+			fxcron.AsCronJob(job.NewPanicCron, `*/1 * * * * *`, gocron.WithLimitedRuns(uint(expectedPanicRuns))),
 		),
 		// deterministic generator for cron job execution id
 		fx.Decorate(uuid.NewFxTestUuidGeneratorFactory),

--- a/fxgenerate/.golangci.yml
+++ b/fxgenerate/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxgenerate/.golangci.yml
+++ b/fxgenerate/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxgenerate/module_test.go
+++ b/fxgenerate/module_test.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package fxgenerate_test
 
 import (

--- a/fxgrpcserver/.golangci.yml
+++ b/fxgrpcserver/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxgrpcserver/.golangci.yml
+++ b/fxgrpcserver/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -51,12 +45,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxhealthcheck/.golangci.yml
+++ b/fxhealthcheck/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxhealthcheck/.golangci.yml
+++ b/fxhealthcheck/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxhttpclient/.golangci.yml
+++ b/fxhttpclient/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxhttpclient/.golangci.yml
+++ b/fxhttpclient/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxhttpserver/.golangci.yml
+++ b/fxhttpserver/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxhttpserver/.golangci.yml
+++ b/fxhttpserver/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -26,17 +24,13 @@ linters:
     - gocritic
     - gocyclo
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -50,12 +44,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxlog/.golangci.yml
+++ b/fxlog/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxlog/.golangci.yml
+++ b/fxlog/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -26,17 +24,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -52,12 +46,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxmcpserver/.golangci.yml
+++ b/fxmcpserver/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxmcpserver/.golangci.yml
+++ b/fxmcpserver/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -53,12 +47,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxmcpserver/register.go
+++ b/fxmcpserver/register.go
@@ -20,7 +20,7 @@ func AsMCPServerTool(constructor any) fx.Option {
 
 // AsMCPServerTools registers several MCP tools.
 func AsMCPServerTools(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsMCPServerTool(constructor))
@@ -42,7 +42,7 @@ func AsMCPServerPrompt(constructor any) fx.Option {
 
 // AsMCPServerPrompts registers several MCP prompts.
 func AsMCPServerPrompts(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsMCPServerPrompt(constructor))
@@ -64,7 +64,7 @@ func AsMCPServerResource(constructor any) fx.Option {
 
 // AsMCPServerResources registers several MCP resources.
 func AsMCPServerResources(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsMCPServerResource(constructor))
@@ -86,7 +86,7 @@ func AsMCPServerResourceTemplate(constructor any) fx.Option {
 
 // AsMCPServerResourceTemplates registers several MCP resource templates.
 func AsMCPServerResourceTemplates(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsMCPServerResourceTemplate(constructor))
@@ -108,7 +108,7 @@ func AsMCPSSEServerContextHook(constructor any) fx.Option {
 
 // AsMCPSSEServerContextHooks registers several MCP SSE server context hooks.
 func AsMCPSSEServerContextHooks(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsMCPSSEServerContextHook(constructor))
@@ -130,7 +130,7 @@ func AsMCPStreamableHTTPServerContextHook(constructor any) fx.Option {
 
 // AsMCPStreamableHTTPServerContextHooks registers several MCP StreamableHTTP server context hooks.
 func AsMCPStreamableHTTPServerContextHooks(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsMCPStreamableHTTPServerContextHook(constructor))

--- a/fxmetrics/.golangci.yml
+++ b/fxmetrics/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxmetrics/.golangci.yml
+++ b/fxmetrics/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -26,17 +24,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -52,12 +46,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxmetrics/register.go
+++ b/fxmetrics/register.go
@@ -18,7 +18,7 @@ func AsMetricsCollector(collector prometheus.Collector) fx.Option {
 
 // AsMetricsCollectors registers a list of [prometheus.Collector] into Fx.
 func AsMetricsCollectors(collectors ...prometheus.Collector) fx.Option {
-	registrations := []fx.Option{}
+	registrations := make([]fx.Option, 0, len(collectors))
 
 	for _, collector := range collectors {
 		registrations = append(

--- a/fxorm/.golangci.yml
+++ b/fxorm/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxorm/.golangci.yml
+++ b/fxorm/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -13,7 +12,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -25,17 +23,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -51,12 +45,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxsql/.golangci.yml
+++ b/fxsql/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxsql/.golangci.yml
+++ b/fxsql/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -53,12 +47,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxsql/register.go
+++ b/fxsql/register.go
@@ -18,7 +18,7 @@ func AsSQLHook(constructor any) fx.Option {
 
 // AsSQLHooks registers a list of [sql.Hook] into Fx.
 func AsSQLHooks(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsSQLHook(constructor))
@@ -40,7 +40,7 @@ func AsSQLSeed(constructor any) fx.Option {
 
 // AsSQLSeeds registers a list of [Seed] into Fx.
 func AsSQLSeeds(constructors ...any) fx.Option {
-	options := []fx.Option{}
+	options := make([]fx.Option, 0, len(constructors))
 
 	for _, constructor := range constructors {
 		options = append(options, AsSQLSeed(constructor))

--- a/fxtrace/.golangci.yml
+++ b/fxtrace/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxtrace/.golangci.yml
+++ b/fxtrace/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -26,17 +24,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -52,12 +46,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxvalidator/.golangci.yml
+++ b/fxvalidator/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxvalidator/.golangci.yml
+++ b/fxvalidator/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -53,12 +47,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxworker/.golangci.yml
+++ b/fxworker/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/fxworker/.golangci.yml
+++ b/fxworker/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/fxworker/info.go
+++ b/fxworker/info.go
@@ -28,7 +28,7 @@ func (i *FxWorkerModuleInfo) Data() map[string]interface{} {
 	data := map[string]interface{}{}
 
 	for name, execution := range i.pool.Executions() {
-		var events []map[string]string
+		events := make([]map[string]string, 0, len(execution.Events()))
 		for _, event := range execution.Events() {
 			events = append(events, map[string]string{
 				"execution": event.ExecutionId(),

--- a/generate/.golangci.yml
+++ b/generate/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/generate/.golangci.yml
+++ b/generate/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/grpcserver/.golangci.yml
+++ b/grpcserver/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/grpcserver/.golangci.yml
+++ b/grpcserver/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/healthcheck/.golangci.yml
+++ b/healthcheck/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/healthcheck/.golangci.yml
+++ b/healthcheck/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/httpclient/.golangci.yml
+++ b/httpclient/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/httpclient/.golangci.yml
+++ b/httpclient/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/httpserver/.golangci.yml
+++ b/httpserver/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/httpserver/.golangci.yml
+++ b/httpserver/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -13,7 +12,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -26,17 +24,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -52,12 +46,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/httpserver/error.go
+++ b/httpserver/error.go
@@ -24,6 +24,8 @@ func NewJsonErrorHandler(obfuscate bool, stack bool) *JsonErrorHandler {
 }
 
 // Handle handles errors.
+//
+//nolint:goconst // "message" is a stable JSON response field name; extracting a constant adds noise without value
 func (h *JsonErrorHandler) Handle() echo.HTTPErrorHandler {
 	return func(err error, c echo.Context) {
 		logger := log.CtxLogger(c.Request().Context())

--- a/httpserver/logger_test.go
+++ b/httpserver/logger_test.go
@@ -273,7 +273,6 @@ func TestFatalLogging(t *testing.T) {
 		echoLogger.Fatal("message")
 	}
 
-	//nolint:gosec
 	cmd := exec.Command(os.Args[0], "-test.run=TestFatalLogging")
 	cmd.Env = append(os.Environ(), "SHOULD_FATAL=1")
 
@@ -302,7 +301,6 @@ func TestFatalFLogging(t *testing.T) {
 		echoLogger.Fatalf("test placeholder message: %s", "placeholder")
 	}
 
-	//nolint:gosec
 	cmd := exec.Command(os.Args[0], "-test.run=TestFatalFLogging")
 	cmd.Env = append(os.Environ(), "SHOULD_FATAL_F=1")
 
@@ -331,7 +329,6 @@ func TestFatalJLogging(t *testing.T) {
 		echoLogger.Fatalj(echologger.JSON{"message": "message"})
 	}
 
-	//nolint:gosec
 	cmd := exec.Command(os.Args[0], "-test.run=TestFatalJLogging")
 	cmd.Env = append(os.Environ(), "SHOULD_FATAL_J=1")
 

--- a/log/.golangci.yml
+++ b/log/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/log/.golangci.yml
+++ b/log/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -53,12 +47,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/orm/.golangci.yml
+++ b/orm/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/orm/.golangci.yml
+++ b/orm/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -13,7 +12,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -25,17 +23,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -51,12 +45,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/orm/plugin/trace.go
+++ b/orm/plugin/trace.go
@@ -101,7 +101,7 @@ func (p *OrmTracerPlugin) after() func(*gorm.DB) {
 
 		var attrs []attribute.KeyValue
 
-		if sys := semconv.DBSystemKey.String(tx.Dialector.Name()); sys.Valid() {
+		if sys := semconv.DBSystemKey.String(tx.Name()); sys.Valid() {
 			attrs = append(attrs, sys)
 		}
 
@@ -114,7 +114,7 @@ func (p *OrmTracerPlugin) after() func(*gorm.DB) {
 			}
 		}
 
-		query := tx.Dialector.Explain(tx.Statement.SQL.String(), vars...)
+		query := tx.Explain(tx.Statement.SQL.String(), vars...)
 
 		attrs = append(attrs, semconv.DBStatementKey.String(query))
 		if tx.Statement.Table != "" {

--- a/sql/.golangci.yml
+++ b/sql/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/sql/.golangci.yml
+++ b/sql/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -53,12 +47,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/trace/.golangci.yml
+++ b/trace/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/trace/.golangci.yml
+++ b/trace/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -14,7 +13,6 @@ linters:
     - decorder
     - dogsled
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -27,17 +25,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -53,12 +47,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/trace/otlp.go
+++ b/trace/otlp.go
@@ -16,10 +16,8 @@ func NewOtlpGrpcClientConnection(ctx context.Context, host string, dialOptions .
 	dialCtx, cancel := context.WithTimeout(ctx, DefaultOtlpGrpcTimeout*time.Second)
 	defer cancel()
 
-	dialContextOptions := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	}
-
+	dialContextOptions := make([]grpc.DialOption, 0, 1+len(dialOptions))
+	dialContextOptions = append(dialContextOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	dialContextOptions = append(dialContextOptions, dialOptions...)
 
 	return grpc.DialContext(dialCtx, host, dialContextOptions...)

--- a/trace/tracetest/exporter.go
+++ b/trace/tracetest/exporter.go
@@ -47,12 +47,12 @@ func (e *DefaultTestTraceExporter) Reset() TestTraceExporter {
 
 // Spans get the [tracetest.SpanStubs] from the in memory internal exporter.
 func (e *DefaultTestTraceExporter) Spans() tracetest.SpanStubs {
-	return e.InMemoryExporter.GetSpans()
+	return e.GetSpans()
 }
 
 // Span get a specific [tracetest.SpanStub] from the in memory internal exporter by name.
 func (e *DefaultTestTraceExporter) Span(name string) (tracetest.SpanStub, error) {
-	for _, span := range e.InMemoryExporter.GetSpans() {
+	for _, span := range e.GetSpans() {
 		if span.Name == name {
 			return span, nil
 		}
@@ -63,7 +63,7 @@ func (e *DefaultTestTraceExporter) Span(name string) (tracetest.SpanStub, error)
 
 // HasSpan return true if a trace span from the in memory internal buffer is exactly matching provided name and attributes.
 func (e *DefaultTestTraceExporter) HasSpan(expectedName string, expectedAttributes ...attribute.KeyValue) bool {
-	for _, span := range e.InMemoryExporter.GetSpans() {
+	for _, span := range e.GetSpans() {
 		if span.Name == expectedName {
 			if len(expectedAttributes) == 0 {
 				return true
@@ -99,7 +99,7 @@ func (e *DefaultTestTraceExporter) HasSpan(expectedName string, expectedAttribut
 //
 //nolint:cyclop,gocognit,exhaustive
 func (e *DefaultTestTraceExporter) ContainSpan(expectedName string, expectedAttributes ...attribute.KeyValue) bool {
-	for _, span := range e.InMemoryExporter.GetSpans() {
+	for _, span := range e.GetSpans() {
 		if span.Name == expectedName {
 			if len(expectedAttributes) == 0 {
 				return true

--- a/worker/.golangci.yml
+++ b/worker/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   concurrency: 8
 linters:
   enable:

--- a/worker/.golangci.yml
+++ b/worker/.golangci.yml
@@ -1,7 +1,6 @@
+version: "2"
 run:
-  timeout: 5m
   concurrency: 8
-
 linters:
   enable:
     - asasalint
@@ -15,7 +14,6 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
@@ -28,17 +26,13 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
     - grouper
     - importas
-    - ineffassign
     - interfacebloat
     - loggercheck
     - maintidx
@@ -54,12 +48,35 @@ linters:
     - predeclared
     - promlinter
     - reassign
-    - staticcheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - whitespace
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go$
+        linters:
+          - goconst
+          - gosec
+          - dupl
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/worker/healthcheck/probe.go
+++ b/worker/healthcheck/probe.go
@@ -43,7 +43,7 @@ func (p *WorkerProbe) SetName(name string) *WorkerProbe {
 // Check returns a successful [healthcheck.CheckerProbeResult] if the worker pool executions are all in healthy status.
 func (p *WorkerProbe) Check(ctx context.Context) *healthcheck.CheckerProbeResult {
 	success := true
-	messages := []string{}
+	messages := make([]string, 0, len(p.pool.Executions()))
 
 	for name, execution := range p.pool.Executions() {
 		if execution.Status() == worker.Unknown || execution.Status() == worker.Error {


### PR DESCRIPTION
## Summary

Migrates the lint stack from golangci-lint v1.64.8 to v2.12.2 across all 28 modules. Follows #443 (common-ci defaults bump, already merged).

## Workflow changes

`.github/workflows/common-ci.yml`:
- `linter_version` default: `1.64.8` → `2.12.2`
- Install path: `github.com/golangci/golangci-lint/cmd/...` → `github.com/golangci/golangci-lint/v2/cmd/...` (v2 lives under `/v2/cmd/`)

## Config migrations

All 28 `.golangci.yml` files migrated via the built-in `golangci-lint migrate` command:
- Added `version: "2"` at the top
- `gofmt` moved under a new top-level `formatters:` section
- v1-default linters (errcheck, govet, staticcheck, etc.) are implied in v2 (auto-enabled)
- `gomodguard` → `gomodguard_v2` (renamed in v2.12)

Added a small exclusion rule to every config to silence test-only noise:

```yaml
exclusions:
  rules:
    - path: _test\.go$
      linters:
        - goconst
        - gosec
        - dupl
```

Without this, v2 would surface ~300 `goconst` findings on JSON-key duplicates across test fixtures — none of which represent real bugs.

## Source-code adjustments

| Module | Change | Reason |
|---|---|---|
| `fxcore/module.go` | Cookie composite literal with `HttpOnly: true` + `SameSite: Lax`, `//nolint:gosec` for `Secure` | dashboard runs on http://localhost in dev; theme is non-sensitive UI state |
| `fxmcpserver/register.go` (6 sites), `fxmetrics/register.go`, `fxsql/register.go` (2 sites), `fxworker/info.go`, `worker/healthcheck/probe.go`, `trace/otlp.go` | `[]T{}` → `make([]T, 0, n)` where final length is known | `prealloc` |
| `orm/plugin/trace.go` (2 sites), `trace/tracetest/exporter.go` (4 sites) | Drop redundant embedded-field qualifier | staticcheck `QF1008` |
| `httpserver/error.go` | `//nolint:goconst` on `Handle()` | `"message"` is a stable JSON response field name across 5 sites |
| `fxcron/module_test.go` (3), `fxgenerate/module_test.go` (1), `httpserver/logger_test.go` (3) | Drop unused `//nolint` directives | v2's checks are stricter about unused suppressions |
