### PR TITLE
feat(httpclient): fail-safe request path normalization

### DIFF
--- a/fxhttpclient/README.md
+++ b/fxhttpclient/README.md
@@ -142,6 +142,12 @@ path label for better cardinality.
 For the given example, if the request path is `/foo/1/bar?page=2`, the metric path label will be masked
 with `/foo/{id}/bar?page={page}`.
 
+When `request_path=true` and no mask matches, the path is sanitized as a fail-safe (rather than emitted
+raw) to prevent metric cardinality explosions: the query string is dropped and identifier-like path
+segments (UUIDs, all-digit, long hex, or segments containing a run of 3+ digits) are replaced with `{id}`.
+For example `/orders/abc-123?page=2` becomes `/orders/{id}`. Explicit masks always take priority;
+add one when you need a specific label for a given route.
+
 Notes:
 
 - the http client logging will be based on the [fxlog](https://github.com/ankorstore/yokai/tree/main/fxlog) module

--- a/httpclient/README.md
+++ b/httpclient/README.md
@@ -223,6 +223,11 @@ map[string]string{
 
 Then if the request path is `/foo/1/bar?page=2`, the metric path label will be masked with `/foo/{fooId}/bar?page={pageId}`.
 
+When `NormalizeRequestPath` is `true` and no mask matches, the path is sanitized via `normalization.SanitizePath`
+as a fail-safe (instead of being emitted raw), to avoid metric cardinality explosions: the query string is dropped
+and identifier-like segments (UUIDs, all-digit, long hex, or segments with a run of 3+ digits) become `{id}`.
+For example `/orders/abc-123?page=2` becomes `/orders/{id}`.
+
 ### Testing
 
 This module provides a [httpclienttest.NewTestHTTPServer()](httpclienttest/server.go) helper for testing your clients against a test server, that allows you:

--- a/httpclient/normalization/path.go
+++ b/httpclient/normalization/path.go
@@ -2,11 +2,35 @@ package normalization
 
 import (
 	"regexp"
+	"strings"
 )
 
-// NormalizePath normalizes a path if matching one of the provided masks, or returns the original path instead.
+// idPlaceholder is the value substituted for identifier-like path segments.
+const idPlaceholder = "{id}"
+
+var (
+	// uuidRegexp matches a canonical UUID path segment.
+	uuidRegexp = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	// numericRegexp matches a path segment made only of digits (e.g. "42").
+	numericRegexp = regexp.MustCompile(`^\d+$`)
+	// longHexRegexp matches long hex segments such as SHA hashes or Mongo ObjectIDs.
+	longHexRegexp = regexp.MustCompile(`^[0-9a-fA-F]{16,}$`)
+	// digitRunRegexp matches any segment containing a run of 3+ digits, which
+	// catches mixed identifiers like "abc-123" or "order-4567" while leaving
+	// version-like segments ("v1", "oauth2", "utf-8") untouched.
+	digitRunRegexp = regexp.MustCompile(`\d{3,}`)
+)
+
+// NormalizePath normalizes a path to keep the resulting metric label low-cardinality.
 //
-// For example: NormalizePath(map[string]string{"/foo/(.+)", "/foo/{id}"}, "/foo/1") will return "/foo/{id}".
+// If the path matches one of the provided masks, the mask is returned (masks take
+// priority and let callers produce human-friendly labels, e.g.
+// NormalizePath(map[string]string{"/foo/(.+)": "/foo/{id}"}, "/foo/1") returns "/foo/{id}").
+//
+// If no mask matches, the path is sanitized via [SanitizePath] instead of being
+// returned as-is. This is a fail-safe default: an un-masked path carrying dynamic
+// identifiers (or a query string) no longer leaks unbounded label values, which
+// would otherwise cause metric cardinality explosions.
 func NormalizePath(masks map[string]string, path string) string {
 	for pattern, mask := range masks {
 		re, err := regexp.Compile(pattern)
@@ -18,5 +42,43 @@ func NormalizePath(masks map[string]string, path string) string {
 		}
 	}
 
-	return path
+	return SanitizePath(path)
+}
+
+// SanitizePath returns a low-cardinality version of a request path by:
+//   - dropping the query string and fragment (everything from '?' or '#' onward), and
+//   - replacing identifier-like segments (UUIDs, all-digit, long hex, or any segment
+//     containing a run of 3+ digits) with the "{id}" placeholder.
+//
+// Segments that look like static route parts (e.g. "v1", "oauth2", "payment-methods")
+// are left unchanged. It is conservative on purpose to avoid masking legitimate routes.
+func SanitizePath(path string) string {
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		path = path[:i]
+	}
+
+	if path == "" {
+		return path
+	}
+
+	segments := strings.Split(path, "/")
+	for i, segment := range segments {
+		if segment == "" {
+			continue
+		}
+
+		if isIdentifierSegment(segment) {
+			segments[i] = idPlaceholder
+		}
+	}
+
+	return strings.Join(segments, "/")
+}
+
+// isIdentifierSegment reports whether a path segment looks like a dynamic identifier.
+func isIdentifierSegment(segment string) bool {
+	return numericRegexp.MatchString(segment) ||
+		uuidRegexp.MatchString(segment) ||
+		longHexRegexp.MatchString(segment) ||
+		digitRunRegexp.MatchString(segment)
 }

--- a/httpclient/normalization/path_test.go
+++ b/httpclient/normalization/path_test.go
@@ -29,24 +29,26 @@ func TestMask(t *testing.T) {
 			"/foo/1/bar?page=1#baz",
 			"/foo/{fooId}/bar?page={pageId}#baz",
 		},
-		"primary mask not applied": {
+		// No mask matches: the path is sanitized (query dropped, id segment masked)
+		// instead of being returned raw.
+		"primary mask not applied falls back to sanitized path": {
 			map[string]string{
 				`/foo/(.+)/bar\?page=(.+)#baz`: "/foo/{fooId}/bar?page={pageId}#baz",
 			},
 			"/foo/1/bar?pages=1#baz",
-			"/foo/1/bar?pages=1#baz",
+			"/foo/{id}/bar",
 		},
-		"primary mask applied on invalid regexp": {
+		"invalid regexp mask falls back to sanitized path": {
 			map[string]string{
 				`(.`: "/foo/{fooId}/bar?page={pageId}#baz",
 			},
 			"/foo/1/bar?page=1#baz",
-			"/foo/1/bar?page=1#baz",
+			"/foo/{id}/bar",
 		},
-		"no mask applied on empty masks list": {
+		"empty masks list falls back to sanitized path": {
 			map[string]string{},
 			"/foo/1/bar?page=1#baz",
-			"/foo/1/bar?page=1#baz",
+			"/foo/{id}/bar",
 		},
 	}
 
@@ -54,6 +56,67 @@ func TestMask(t *testing.T) {
 		got := normalization.NormalizePath(tt.masks, tt.path)
 		if got != tt.want {
 			t.Errorf("%s: expected %s, got %s", name, tt.want, got)
+		}
+	}
+}
+
+func TestSanitizePath(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		path string
+		want string
+	}{
+		"query string dropped": {
+			"/search?q=some-value&page=2",
+			"/search",
+		},
+		"query dropped and mixed id segment masked": {
+			"/orders/abc-123?page=2",
+			"/orders/{id}",
+		},
+		"numeric segment masked": {
+			"/users/42",
+			"/users/{id}",
+		},
+		"uuid segment masked": {
+			"/orders/123e4567-e89b-12d3-a456-426614174000",
+			"/orders/{id}",
+		},
+		"long hex segment masked": {
+			"/blobs/deadbeefdeadbeef00",
+			"/blobs/{id}",
+		},
+		"multiple id segments masked": {
+			"/a/1/b/2",
+			"/a/{id}/b/{id}",
+		},
+		"static segments left untouched": {
+			"/v1/payment-methods/oauth2",
+			"/v1/payment-methods/oauth2",
+		},
+		"short digit in segment left untouched": {
+			"/enc/utf-8",
+			"/enc/utf-8",
+		},
+		"path without id or query unchanged": {
+			"/health",
+			"/health",
+		},
+		"root path unchanged": {
+			"/",
+			"/",
+		},
+		"empty path unchanged": {
+			"",
+			"",
+		},
+	}
+
+	for name, tt := range tests {
+		got := normalization.SanitizePath(tt.path)
+		if got != tt.want {
+			t.Errorf("%s: expected %q, got %q", name, tt.want, got)
 		}
 	}
 }

--- a/httpclient/transport/metrics_test.go
+++ b/httpclient/transport/metrics_test.go
@@ -110,7 +110,7 @@ func TestMetricsTransportRoundTripWithBaseAndConfig(t *testing.T) {
 			# HELP foo_bar_http_client_requests_total Number of performed HTTP requests
 			# TYPE foo_bar_http_client_requests_total counter
     		foo_bar_http_client_requests_total{host="%s",method="GET",path="",status="204"} 1
-    		foo_bar_http_client_requests_total{host="%s",method="GET",path="/foo/4/baz",status="204"} 1
+    		foo_bar_http_client_requests_total{host="%s",method="GET",path="/foo/{id}/baz",status="204"} 1
     		foo_bar_http_client_requests_total{host="%s",method="GET",path="/foo/{fooId}/bar?page={pageId}",status="204"} 3
 		`,
 		server.URL,


### PR DESCRIPTION
## What & why

Yokai's HTTP-client metrics record a `path` label built from the request path plus its query string. `NormalizePath` is an allowlist of regex→template masks: if a mask matches it returns a friendly template, but **if nothing matches it returns the raw path+query unchanged**. Any un-masked route carrying a dynamic identifier (a UUID/number in the path, or a value in the query string) therefore leaks an unbounded set of values into the `path` label of `http_client_requests_*`, which can explode metric cardinality and OOM a downstream Prometheus/Thanos.

Because masking is opt-in per-route, this is easy to trigger by accident: one new client call with a dynamic path/query and a forgotten mask is enough.

## What this changes

`NormalizePath` now **sanitizes** the path when no mask matches, instead of returning it raw (only when `NormalizeRequestPath` is enabled). New exported helper `SanitizePath`:

- drops the query string and fragment (everything from `?` / `#`), and
- replaces identifier-like segments with `{id}`: UUIDs, all-digit segments, long hex (≥16), or any segment containing a run of 3+ digits (catches `abc-123`, `order-4567`).

Segments that look like static route parts (`v1`, `oauth2`, `payment-methods`) are left untouched — the heuristic is intentionally conservative to avoid mangling real routes. Explicit masks still take priority, so existing friendly labels are unchanged.

Example (no mask matches): `/orders/abc-123?page=2` → `/orders/{id}`.

## Behavior change

`NormalizePath` no longer returns an un-matched path verbatim; on a miss it returns the sanitized value. This only changes metric label values, and only when `NormalizeRequestPath` is `true`. Happy to gate it behind a new opt-in flag or flag it as a breaking release instead — let me know your preference.

## Tests

- `normalization`: updated the fallback expectations and added `TestSanitizePath` (UUID / numeric / long-hex / mixed-id / static / query / root / empty).
- `transport`: updated the un-masked assertion (`/foo/4/baz` → `/foo/{id}/baz`).
- `go test ./...` is green for the `httpclient` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
