### PR TITLE
ci: bump coverage workflow default Go version to 1.26

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ on:
       go_version:
         required: false
         type: string
-        default: "1.20.0"
+        default: "1.26"
 
 permissions:
   contents: write


### PR DESCRIPTION
## What's failing

The `coverage` workflow (`.github/workflows/coverage.yml`), which runs on **push to `main`**, is failing for **every module** in its matrix (`config`, `fxcore`, `fxclock`, `httpclient`, …) with:

```
go: go.mod requires go >= 1.26.0 (running go 1.24.13; GOTOOLCHAIN=local)
Error: Process completed with exit code 1.
```

## Root cause

`coverage.yml` declares a default `go_version` of **`"1.20.0"`**, and nothing overrides it on the push-to-main trigger. But all modules were bumped to require **Go ≥ 1.26.0** (`go 1.26.0` / `toolchain go1.26.4` in every `go.mod`). Since `GOTOOLCHAIN=local` prevents the runner from downloading a newer toolchain, `go mod download` fails before any test runs — for all modules.

This is unrelated to any module change; it fails on every push to `main`. Per-module PR CI is unaffected because it goes through `common-ci.yml`, which already defaults to `go_version: "1.26"`.

## Fix

Align `coverage.yml`'s default with `common-ci.yml`:

```diff
       go_version:
         required: false
         type: string
-        default: "1.20.0"
+        default: "1.26"
```

One-line change; no other workflow behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
