### PR TITLE
ci: fall back to Go 1.26 in coverage workflow on push events

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version: ${{ inputs.go_version || '1.26' }}
       - name: Install dependencies for module ${{ matrix.module }}
         working-directory: ${{ matrix.module }}
         run: go mod download


### PR DESCRIPTION
## What's failing

`coverage.yml` (runs on **push to `main`**) fails for **all 28 modules** at `go mod download`:
```
go: go.mod requires go >= 1.26.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

## Root cause

The workflow reads `go-version: ${{ inputs.go_version }}`. Input **`default`s only apply on `workflow_call` / `workflow_dispatch`, not on `push`.** On a push event, `inputs` is empty, so `go-version` resolves to an empty string → `actions/setup-go` installs nothing → the runner's **preinstalled Go 1.24.13** is used. That's below the modules' required `1.26.0`, and `GOTOOLCHAIN=local` prevents fetching a newer toolchain, so `go mod download` fails.

Confirmed in the latest run: **every** module — including the ones fail-fast marked "cancelled" — failed identically at `go mod download` with `running go 1.24.13`, even though the "Install Go" step was green.

(This is why #448, which only bumped the input `default` to `"1.26"`, had no effect on the push-triggered run.)

## Fix

```diff
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version: ${{ inputs.go_version || '1.26' }}
```

On push (empty `inputs`) this resolves to `1.26` → setup-go installs Go 1.26.x (same as `common-ci.yml`, satisfies `go 1.26.0` / `toolchain go1.26.4`). It still honors an explicit value when the workflow is `workflow_call`-ed.

Follow-up to #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
