### PR TITLE
chore(fxhttpclient): bump httpclient to v1.7.0

### DIFF
--- a/fxhttpclient/go.mod
+++ b/fxhttpclient/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ankorstore/yokai/fxlog v1.1.0
 	github.com/ankorstore/yokai/fxmetrics v1.1.0
 	github.com/ankorstore/yokai/fxtrace v1.2.0
-	github.com/ankorstore/yokai/httpclient v1.4.0
+	github.com/ankorstore/yokai/httpclient v1.7.0
 	github.com/ankorstore/yokai/log v1.2.0
 	github.com/ankorstore/yokai/trace v1.2.0
 	github.com/prometheus/client_golang v1.19.0

--- a/fxhttpclient/go.sum
+++ b/fxhttpclient/go.sum
@@ -8,8 +8,8 @@ github.com/ankorstore/yokai/fxmetrics v1.1.0 h1:S0bLCwO37oiDG+5kQFGYt2g2FNGQLu/O
 github.com/ankorstore/yokai/fxmetrics v1.1.0/go.mod h1:WBr76IIdlSZIpBsjKSdXCAJBWF0HCp46bwFX8bt0tFk=
 github.com/ankorstore/yokai/fxtrace v1.2.0 h1:SXlWbjKSsb2wVH+hXSE9OD2VwyqkznwwW+kiQcNvEAU=
 github.com/ankorstore/yokai/fxtrace v1.2.0/go.mod h1:ch72eVTlIedETOApK7SXk2NEWpn3yYeM018dNRccocg=
-github.com/ankorstore/yokai/httpclient v1.4.0 h1:m3pMhY62wj96J/k7C4Dv0a2eIQZyLa2O337DRNzTpvw=
-github.com/ankorstore/yokai/httpclient v1.4.0/go.mod h1:sBg8v79VgHtShuGUTo+BwWqvim7Ubd9eoWMJqK3MCwg=
+github.com/ankorstore/yokai/httpclient v1.7.0 h1:aUXPal+A/q7DO+LD7UArB3i3/h1uryicR614MeHHnI8=
+github.com/ankorstore/yokai/httpclient v1.7.0/go.mod h1:N9WFGcYB7tgPmPqLTLY8xGPxzuJ47oWkdA/BZ4zxqKo=
 github.com/ankorstore/yokai/log v1.2.0 h1:jiuDiC0dtqIGIOsFQslUHYoFJ1qjI+rOMa6dI1LBf2Y=
 github.com/ankorstore/yokai/log v1.2.0/go.mod h1:MVvUcms1AYGo0BT6l88B9KJdvtK6/qGKdgyKVXfbmyc=
 github.com/ankorstore/yokai/trace v1.2.0 h1:Jnl++IGNpDYumsZJXP3qjhMdvyHbejiajQwIlU604w0=


### PR DESCRIPTION
## Summary

Bumps `fxhttpclient`'s dependency on the `httpclient` module from **v1.4.0 → v1.7.0**.

`fxhttpclient` is a thin Fx wrapper that builds its HTTP clients from `httpclient`'s factory/transport (`module.go`). It carried no code change for the fail-safe request path normalization shipped in `httpclient` v1.7.0 (#445) because its `go.mod` still pinned `httpclient v1.4.0`. This bump makes the clients `fxhttpclient` produces actually include that fix.

## Changes

- `fxhttpclient/go.mod`: `httpclient v1.4.0` → `v1.7.0`
- `fxhttpclient/go.sum`: updated via `go mod tidy`

## Verification

- `go build ./...` ✅
- `go test ./...` ✅

## Notes

- No behavior/code change in `fxhttpclient` itself — dependency bump only.
- Non-breaking to publish; existing consumers are unaffected until they opt in by bumping `fxhttpclient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)